### PR TITLE
Eager load vercel logo on Claim Deployment button

### DIFF
--- a/app/claim/claim-deployment-button.tsx
+++ b/app/claim/claim-deployment-button.tsx
@@ -28,6 +28,7 @@ export default function ClaimDeploymentButton({ code }: { code: string }) {
           width={17}
           height={17}
           className="mr-2"
+          loading="eager"
         />
         Claim Deployment
       </button>


### PR DESCRIPTION
The logo is above the fold, so load it immediately.