### PR TITLE
Make the template boxes smaller on mobile

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
       lang="en"
       className={`${GeistSans.variable} ${GeistMono.variable} antialiased h-full`}
     >
-      <body className="flex min-h-full flex-col flex-col justify-between items-center sm:bg-neutral-50 pt-5 sm:px-6">
+      <body className="flex min-h-full flex-col flex-col justify-between items-center sm:bg-neutral-50 sm:px-6">
         <div className="flex-1 sm:flex-none bg-white rounded-xl sm:shadow-md overflow-hidden sm:border sm:border-neutral-200 p-6 sm:my-auto w-full max-w-2xl">
           {children}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -207,7 +207,7 @@ export default function Home() {
                 {templates.map((template) => (
                   <div
                     key={template.id}
-                    className={`cursor-pointer transition-all p-6 rounded-lg border ${
+                    className={`cursor-pointer transition-all sm:p-6 p-2 pt-3 rounded-lg border  ${
                       selectedTemplate === template.id
                         ? "bg-neutral-100 border"
                         : "hover:border-neutral-300"


### PR DESCRIPTION
Adjusts the template boxes on mobile to be smaller, ensuring that logs fit within a single screen view on most phone screens. 

| Before | After |
|--------|-------|
| ![4ae9f1e2-f282-4eb8-9adf-f84968621df7](https://github.com/user-attachments/assets/98b9ed53-a92d-4523-a7ff-62e13f2e8fe0) | ![bdfb2f2d-fa5e-476f-90e6-f065d62b3b09](https://github.com/user-attachments/assets/2f40f6ed-8bb7-47b7-b050-c91eb2fc767e) |
